### PR TITLE
修改BS函数计算方式

### DIFF
--- a/cmduplugin.cpp
+++ b/cmduplugin.cpp
@@ -203,23 +203,14 @@ QString CMDUPlugin::KB(long k)
 
 QString CMDUPlugin::BS(long b)
 {
-    QString s = "";
-    if(b > 999999999){
-        //s = QString("%1").arg(b/(1024*1024*1024.0), 6, 'f', 2, QLatin1Char(' ')) + "GB";
-        s = QString::number(b/(1024*1024*1024.0), 'f', 2) + "GB";
-    }else{
-        if(b > 999999){
-            //s = QString("%1").arg(b/(1024*1024.0), 6, 'f', 2, QLatin1Char(' ')) + "MB";
-            s = QString::number(b/(1024*1024.0), 'f', 2) + "MB";
-        }else{
-            if(b>999){
-                //s = QString("%1").arg(b/1024.0, 6, 'f', 2, QLatin1Char(' ')) + "KB";
-                s = QString::number(b/(1024.0), 'f',2) + "KB";
-            }else{
-                s = b + "B";
-            }
-        }
+    size_t index = 0;
+    QString szType[] = {"B", "KB", "MB", "GB", "TB"};
+    while (b > 1024)
+    {
+        b /= 1024.0;
+        ++ index;
     }
+    QString s = QString::number(b, 'f', 2) + szType[index];
     return s;
 }
 


### PR DESCRIPTION
我在我本地默认将docker显示的数据设置成了BS函数这个计算方式，动态变换网速的单位。但是发现BS这个函数在我本地计算的数值不正确。然后就修改了一下这个BS的网速计算方式。